### PR TITLE
Fixes/Issue with Comment Preview URL in GitHub Actions Workflow Step

### DIFF
--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -5,7 +5,7 @@ env:
   BRANCH_NAME: ${{ github.ref_name }}
 on: [push]
 permissions:
-  # give this workflow permission to comment out deployed preview url
+  # give this workflow permission to comment deployed preview url in the PR
   pull-requests: write
 jobs:
   deploy-app:
@@ -64,24 +64,12 @@ jobs:
         with:
           script: |
             async function commentPreviewUrlOnPR() {
-              const result = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+              await github.rest.issues.createComment({
+                issue_number: context.issue.number,
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                commit_sha: context.sha,
+                body: 'Preview URL: ' + process.env.NETLIFY_PREVIEW_URL
               })
-
-              const issueNumber = result.data[0].number
-
-              if (issueNumber) {
-                await github.rest.issues.createComment({
-                  issue_number: issueNumber,
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  body: 'Preview URL: ' + process.env.NETLIFY_PREVIEW_URL
-                })
-              } else {
-                console.log('No PR found for the commit ' + context.sha)
-              }
             }
 
             commentPreviewUrlOnPR()

--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -5,7 +5,7 @@ env:
   BRANCH_NAME: ${{ github.ref_name }}
 on: [push]
 permissions:
-  # give this workflow permission to comment deployed preview url in the PR
+  # give this workflow permission to comment deployed preview url on the PR
   pull-requests: write
 jobs:
   deploy-app:
@@ -64,12 +64,25 @@ jobs:
         with:
           script: |
             async function commentPreviewUrlOnPR() {
-              await github.rest.issues.createComment({
-                issue_number: context.issue.number,
+              const result = await github.rest.repos.listPullRequestsAssociatedWithCommit({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                body: 'Preview URL: ' + process.env.NETLIFY_PREVIEW_URL
+                commit_sha: context.sha,
               })
+
+              // adding the optional chaining operator since a pull request is not available or created during the first commit push for a new branch
+              const issueNumber = result.data[0]?.number;
+
+              if (issueNumber) {
+                await github.rest.issues.createComment({
+                  issue_number: issueNumber,
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  body: 'Preview URL: ' + process.env.NETLIFY_PREVIEW_URL
+                })
+              } else {
+                console.log('No PR found for the commit ' + context.sha)
+              }
             }
 
             commentPreviewUrlOnPR()


### PR DESCRIPTION
## Tasks Done
- Add the optional chaining operator i.e., `?.` since a pull request is not available or created during the first commit push for a new branch